### PR TITLE
Correcao do botao 'Paginas' quebrado na busca.

### DIFF
--- a/busca/templates/busca.html
+++ b/busca/templates/busca.html
@@ -40,7 +40,7 @@
             <a href="busca/ata?q={{query}}" class="btn btn-primary">Atas</a>
         {% endif %}
         {% if paginas %}
-            <a href="busca/paginas?q={{query}}" class="btn btn-primary">Paginas</a>
+            <a href="busca/pagina?q={{query}}" class="btn btn-primary">Paginas</a>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
Quando se usa a busca do site e encontra-se múltiplos resultados, os botões Atas, Notícias e Págians são mostrados.

Ao clica no botão Páginas, o link está quebrado (404).