### PR TITLE
Atualizando futuro nome do arquivo do manual

### DIFF
--- a/.nginx-docker/nginx.conf
+++ b/.nginx-docker/nginx.conf
@@ -102,7 +102,7 @@ http {
         # Serve the manual
         location /manual.pdf {
             sendfile on;
-            alias /manual/manual_do_bixo.pdf;
+            alias /manual/manual_dx_bixx.pdf;
         }
 
         # The "rest"


### PR DESCRIPTION
O script diário no servidor foi atualizado para copiar o novo nome e já está funcionando.

Basta atualizar o _nginx.conf_ do servidor, reiniciar o serviço e estará tudo funcionando.